### PR TITLE
`textAlign` props should not be mandatory in `<Text />`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+# v1.3.1 (Tue Feb 13 2024)
+
+#### 🐛 Bug Fix
+
+- Fix errors when implementing `@inubekit/text` [#6](https://github.com/selsa-inube/inubekit-text/pull/6) ([@Andresbl123](https://github.com/Andresbl123))
+
+#### ⚠️ Pushed to `main`
+
+- refactor(Text): update ITextProps interface to make textAlign prop optional (carlos3k11@gmail.com)
+
+#### Authors: 2
+
+- Andres ([@Andresbl123](https://github.com/Andresbl123))
+- Andres Babativa (carlos3k11@gmail.com)
+
+---
+
 # v1.2.1 (Fri Feb 02 2024)
 
 #### 🐛 Bug Fix

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@inubekit/text",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@inubekit/text",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "dependencies": {
         "@inubekit/foundations": "^1.1.2",
         "react": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   ],
   "description": "",
   "private": false,
-  "version": "1.3.0",
+  "version": "1.3.1",
   "type": "module",
   "exports": {
     ".": {

--- a/src/Text/index.tsx
+++ b/src/Text/index.tsx
@@ -10,7 +10,7 @@ import {
 
 export interface ITextProps {
   children?: React.ReactNode;
-  textAlign: AlignOptions;
+  textAlign?: AlignOptions;
   margin?: string;
   padding?: string;
   as?: HtmlElements;


### PR DESCRIPTION
ℹ  info      New Release Notes
 #### 🐛 Bug Fix

- Fix errors when implementing `@inubekit/text` [#6](https://github.com/selsa-inube/inubekit-text/pull/6) ([@Andresbl123](https://github.com/Andresbl123))

#### ⚠️ Pushed to `main`

- refactor(Text): update ITextProps interface to make textAlign prop optional (carlos3k11@gmail.com)

#### Authors: 2

- Andres ([@Andresbl123](https://github.com/Andresbl123))
- Andres Babativa (carlos3k11@gmail.com)