### PR TITLE
Extend `<Text />` Component to Include weight Prop

### DIFF
--- a/src/Text/Text.stories.tsx
+++ b/src/Text/Text.stories.tsx
@@ -1,5 +1,5 @@
-import { props, parameters } from "./props";
 import { Text, IText } from ".";
+import { parameters, props } from "./props";
 
 const story = {
   title: "data/Text",
@@ -13,18 +13,19 @@ const Default = (args: IText) => {
 };
 
 Default.args = {
-  children: "Title with the Text component",
+  appearance: "dark",
   as: "h1",
-  textAlign: "start",
+  children: "Title with the Text component",
+  cursorHover: true,
+  disabled: false,
+  ellipsis: false,
   margin: "20px 22px 23px 24px",
   padding: "5px",
-  appearance: "dark",
-  type: "body",
-  size: "large",
-  disabled: false,
-  cursorHover: true,
-  ellipsis: false,
   parentHover: false,
+  size: "large",
+  textAlign: "start",
+  type: "body",
+  weight: "normal",
 };
 
 export { Default };

--- a/src/Text/index.tsx
+++ b/src/Text/index.tsx
@@ -2,56 +2,60 @@ import { StyledText } from "./styles";
 
 import {
   ITextAlignment,
+  ITextAppearance,
   ITextHtmlElement,
   ITextSize,
   ITextType,
-  ITextAppearance,
+  ITextWeight,
 } from "./props";
 
 interface IText {
+  appearance?: ITextAppearance;
+  as?: ITextHtmlElement;
   children?: React.ReactNode;
-  textAlign?: ITextAlignment;
+  cursorHover?: boolean;
+  disabled?: boolean;
+  ellipsis?: boolean;
   margin?: string;
   padding?: string;
-  as?: ITextHtmlElement;
-  appearance?: ITextAppearance;
-  disabled?: boolean;
-  type?: ITextType;
-  size?: ITextSize;
-  cursorHover?: boolean;
   parentHover?: boolean;
-  ellipsis?: boolean;
+  size?: ITextSize;
+  textAlign?: ITextAlignment;
+  type?: ITextType;
+  weight?: ITextWeight;
 }
 
 const Text = (props: IText) => {
   const {
+    appearance = "dark",
+    as = "p",
     children,
-    textAlign = "start",
+    cursorHover = false,
+    disabled = false,
+    ellipsis = false,
     margin = "0px",
     padding = "0px",
-    as = "p",
-    appearance = "dark",
-    type = "body",
-    size = "large",
-    cursorHover = false,
     parentHover = false,
-    ellipsis = false,
-    disabled = false,
+    size = "large",
+    textAlign = "start",
+    type = "body",
+    weight = "normal",
   } = props;
 
   return (
     <StyledText
       as={as}
-      $textAlign={textAlign}
       $appearance={appearance}
-      $type={type}
-      $size={size}
+      $cursorHover={cursorHover}
+      $disabled={disabled}
+      $ellipsis={ellipsis}
       $margin={margin}
       $padding={padding}
-      $cursorHover={cursorHover}
       $parentHover={parentHover}
-      $ellipsis={ellipsis}
-      $disabled={disabled}
+      $size={size}
+      $textAlign={textAlign}
+      $type={type}
+      $weight={weight}
     >
       {children}
     </StyledText>

--- a/src/Text/props.ts
+++ b/src/Text/props.ts
@@ -1,19 +1,4 @@
-const aligments = ["start", "center", "end", "justify"] as const;
-const htmlElements = [
-  "h1",
-  "h2",
-  "h3",
-  "h4",
-  "h5",
-  "h6",
-  "p",
-  "span",
-  "legend",
-  "figcaption",
-  "blockquote",
-] as const;
-const sizes = ["large", "medium", "small"] as const;
-const types = ["body", "display", "label", "title", "headline"] as const;
+const alignments = ["start", "center", "end", "justify"] as const;
 const appearances = [
   "primary",
   "success",
@@ -24,16 +9,29 @@ const appearances = [
   "gray",
   "light",
 ] as const;
+const htmlElements = [
+  "blockquote",
+  "figcaption",
+  "h1",
+  "h2",
+  "h3",
+  "h4",
+  "h5",
+  "h6",
+  "legend",
+  "p",
+  "span",
+] as const;
+const sizes = ["large", "medium", "small"] as const;
+const types = ["body", "display", "headline", "label", "title"] as const;
+const weights = ["normal", "bold"] as const;
 
-type ITextAlignment = (typeof aligments)[number];
-
+type ITextAlignment = (typeof alignments)[number];
 type ITextAppearance = (typeof appearances)[number];
-
 type ITextHtmlElement = (typeof htmlElements)[number];
-
 type ITextSize = (typeof sizes)[number];
-
 type ITextType = (typeof types)[number];
+type ITextWeight = (typeof weights)[number];
 
 const parameters = {
   docs: {
@@ -45,26 +43,13 @@ const parameters = {
 };
 
 const props = {
-  textAlign: {
-    options: aligments,
+  appearance: {
+    options: appearances,
     control: { type: "select" },
-    description: "This prop controls the text-align style property.",
-    table: {
-      defaultValue: { summary: "start" },
-    },
-  },
-  margin: {
     description:
-      "Sets the margin in px or global values for all four sides of the component.",
+      "This prop is used to select one of the color system tokens of the role Text as defined in the Foundations.",
     table: {
-      defaultValue: { summary: "0px" },
-    },
-  },
-  padding: {
-    description:
-      "Sets the padding in px p global values for all four sides of the component",
-    table: {
-      defaultValue: { summary: "0px" },
+      defaultValue: { summary: "dark" },
     },
   },
   as: {
@@ -76,21 +61,9 @@ const props = {
       defaultValue: { summary: "<p>" },
     },
   },
-  disabled: {
+  children: {
     description:
-      "(boolean): Add the “disabled” prop, which will control if the text should display a disabled state. For this you can make use of the disabled modifiers you find in the color.text tokens.",
-    table: {
-      defaultValue: { summary: "false" },
-    },
-  },
-  ITextAppearance: {
-    options: appearances,
-    control: { type: "select" },
-    description:
-      "This prop is used to select one of the color system tokens of the role Text as defined in the Foundations.",
-    table: {
-      defaultValue: { summary: "dark" },
-    },
+      "This prop allows the component to get and print text on the screen.",
   },
   cursorHover: {
     description:
@@ -99,18 +72,53 @@ const props = {
       defaultValue: { summary: "false" },
     },
   },
-  parentHover: {
+  disabled: {
     description:
-      "(boolean): prop to force the text to always appear in its hover state. This works when the parent is being hover (not the text), but the parent must display as if all the component is",
+      "(boolean): Add the “disabled” prop, which will control if the text should display a disabled state. For this you can make use of the disabled modifiers you find in the color.text tokens.",
     table: {
       defaultValue: { summary: "false" },
     },
   },
   ellipsis: {
     description:
-      "(boolean): Add the ellipsis prop to control that the text cannot overflow or resize the parent.Instead, the text will be shown as much as possible in the available space and the rest of it will be replaced with an ellipsis.To make this work you must use the overflow, white - space and text - overflow CSS properties.",
+      "(boolean): Add the ellipsis prop to control that the text cannot overflow or resize the parent. Instead, the text will be shown as much as possible in the available space and the rest of it will be replaced with an ellipsis. To make this work you must use the overflow, white-space and text-overflow CSS properties.",
     table: {
       defaultValue: { summary: "false" },
+    },
+  },
+  margin: {
+    description:
+      "Sets the margin in px or global values for all four sides of the component.",
+    table: {
+      defaultValue: { summary: "0px" },
+    },
+  },
+  padding: {
+    description:
+      "Sets the padding in px or global values for all four sides of the component.",
+    table: {
+      defaultValue: { summary: "0px" },
+    },
+  },
+  parentHover: {
+    description:
+      "(boolean): prop to force the text to always appear in its hover state. This works when the parent is being hovered (not the text), but the parent must display as if all the component is.",
+    table: {
+      defaultValue: { summary: "false" },
+    },
+  },
+  size: {
+    options: sizes,
+    control: { type: "select" },
+    description:
+      "This prop is used to select one of the typography roles defined in the Foundations.",
+  },
+  textAlign: {
+    options: alignments,
+    control: { type: "select" },
+    description: "This prop controls the text-align style property.",
+    table: {
+      defaultValue: { summary: "start" },
     },
   },
   type: {
@@ -122,16 +130,14 @@ const props = {
       defaultValue: { summary: "bodyLarge" },
     },
   },
-  ITextSize: {
-    options: sizes,
+  weight: {
+    options: weights,
     control: { type: "select" },
     description:
       "This prop is used to select one of the typography roles defined in the Foundations.",
-  },
-
-  children: {
-    description:
-      "This prop allows the component to get and print text in the screen.",
+    table: {
+      defaultValue: { summary: "normal" },
+    },
   },
 };
 
@@ -142,4 +148,5 @@ export type {
   ITextHtmlElement,
   ITextSize,
   ITextType,
+  ITextWeight,
 };

--- a/src/Text/styles.js
+++ b/src/Text/styles.js
@@ -11,7 +11,7 @@ const StyledText = styled.p`
   font-size: ${({ $type, $size }) => inube.typography[$type][$size].size};
   letter-spacing: ${({ $type, $size }) =>
     inube.typography[$type][$size].tracking};
-  font-weight: ${({ $type, $size }) => inube.typography[$type][$size].weight};
+  font-weight: ${({ $weight }) => ($weight === "bold" ? 500 : 400)};
   margin: ${({ $margin }) => $margin};
   padding: ${({ $padding }) => $padding};
   text-align: ${({ $textAlign }) => $textAlign};


### PR DESCRIPTION
This PR extends the `<Text />` component to include a new weight prop. The weight prop allows users to specify the font weight of the text rendered by the `<Text />` component. By adding this prop, we enhance the flexibility and customization options available for text styling within our application.