### PR TITLE
Extend `<Text />` Component to Include an `onClick` Prop

### DIFF
--- a/src/Text/Text.stories.tsx
+++ b/src/Text/Text.stories.tsx
@@ -1,5 +1,6 @@
 import { Text, IText } from ".";
 import { parameters, props } from "./props";
+import { action } from "@storybook/addon-actions";
 
 const story = {
   title: "data/Text",
@@ -22,6 +23,7 @@ Default.args = {
   margin: "20px 22px 23px 24px",
   padding: "5px",
   parentHover: false,
+  onClick: action("onClick"),
   size: "large",
   textAlign: "start",
   type: "body",

--- a/src/Text/index.tsx
+++ b/src/Text/index.tsx
@@ -19,6 +19,7 @@ interface IText {
   margin?: string;
   padding?: string;
   parentHover?: boolean;
+  onClick?: (event: Event) => void;
   size?: ITextSize;
   textAlign?: ITextAlignment;
   type?: ITextType;
@@ -36,11 +37,21 @@ const Text = (props: IText) => {
     margin = "0px",
     padding = "0px",
     parentHover = false,
+    onClick,
     size = "large",
     textAlign = "start",
     type = "body",
     weight = "normal",
   } = props;
+
+  function handleClick(event: Event) {
+    if (disabled) return;
+    try {
+      onClick && onClick(event);
+    } catch (error) {
+      console.error(`Error when clicking over select. ${error}`);
+    }
+  }
 
   return (
     <StyledText
@@ -52,6 +63,7 @@ const Text = (props: IText) => {
       $margin={margin}
       $padding={padding}
       $parentHover={parentHover}
+      onClick={handleClick}
       $size={size}
       $textAlign={textAlign}
       $type={type}

--- a/src/Text/props.ts
+++ b/src/Text/props.ts
@@ -107,6 +107,10 @@ const props = {
       defaultValue: { summary: "false" },
     },
   },
+  onClick: {
+    description:
+      "This prop allows us to control what happens when the component is clicked.",
+  },
   size: {
     options: sizes,
     control: { type: "select" },


### PR DESCRIPTION
This pull request extends the `<Text />` component by adding support for an `onClick` prop. This enhancement allows developers to attach click event handlers to the `<Text />` component, making it more interactive and versatile in various use cases.