### PR TITLE
Move text tokens from foundations to component

### DIFF
--- a/src/Text/Tokens/tokens.ts
+++ b/src/Text/Tokens/tokens.ts
@@ -1,0 +1,78 @@
+import { inube } from "@inubekit/foundations";
+
+const tokens = {
+  primary: {
+    content: {
+      color: {
+        regular: inube.palette.blue.B400,
+        disabled: inube.palette.neutral.N70,
+        hover: inube.palette.blue.B300,
+      },
+    },
+  },
+  success: {
+    content: {
+      color: {
+        regular: inube.palette.green.G400,
+        disabled: inube.palette.neutral.N70,
+        hover: inube.palette.green.G300,
+      },
+    },
+  },
+  warning: {
+    content: {
+      color: {
+        regular: inube.palette.yellow.Y400,
+        disabled: inube.palette.neutral.N70,
+        hover: inube.palette.yellow.Y300,
+      },
+    },
+  },
+  danger: {
+    content: {
+      color: {
+        regular: inube.palette.red.R400,
+        disabled: inube.palette.neutral.N70,
+        hover: inube.palette.red.R300,
+      },
+    },
+  },
+  help: {
+    content: {
+      color: {
+        regular: inube.palette.purple.P400,
+        disabled: inube.palette.neutral.N70,
+        hover: inube.palette.purple.P300,
+      },
+    },
+  },
+  dark: {
+    content: {
+      color: {
+        regular: inube.palette.neutral.N900,
+        disabled: inube.palette.neutral.N70,
+        hover: inube.palette.neutral.N500,
+      },
+    },
+  },
+  gray: {
+    content: {
+      color: {
+        regular: inube.palette.neutral.N300,
+        disabled: inube.palette.neutral.N70,
+        hover: inube.palette.neutral.N100,
+      },
+    },
+  },
+  light: {
+    content: {
+      color: {
+        regular: inube.palette.neutral.N10,
+        disabled: inube.palette.neutral.N70,
+        hover: inube.palette.neutral.N0,
+      },
+    },
+  },
+};
+
+export { tokens };

--- a/src/Text/styles.js
+++ b/src/Text/styles.js
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-
+import { tokens } from "./Tokens/tokens";
 import { inube } from "@inubekit/foundations";
 
 const StyledText = styled.p`
@@ -19,18 +19,18 @@ const StyledText = styled.p`
     if ($disabled) {
       return (
         theme?.text?.[$appearance]?.content?.color?.disabled ||
-        inube.text[$appearance].content.color.disabled
+        tokens[$appearance].content.color.disabled
       );
     }
     if ($parentHover) {
       return (
         theme?.text?.[$appearance]?.content?.color?.hover ||
-        inube.text[$appearance].content.color.hover
+        tokens[$appearance].content.color.hover
       );
     }
     return (
       theme?.text?.[$appearance]?.content?.color?.regular ||
-      inube.text[$appearance].content.color.regular
+      tokens[$appearance].content.color.regular
     );
   }};
 
@@ -45,7 +45,7 @@ const StyledText = styled.p`
       !$disabled &&
       $cursorHover &&
       (theme?.text?.[$appearance]?.content?.color?.hover ||
-        inube.text[$appearance].content.color.hover)};
+        tokens[$appearance].content.color.hover)};
   }
 `;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,3 +7,4 @@ export type {
   ITextSize,
   ITextType,
 } from "./Text/props";
+export { tokens as TextTokens } from "./Text/Tokens/tokens";


### PR DESCRIPTION
This PR relocates the text tokens from the foundations folder to the respective component folder, updating all necessary imports to match the new structure and ensuring that components are referencing the correct token paths. The changes improve the organization, maintainability, and clarity of the token usage within the codebase.