### PR TITLE
Adjust text tokens to change "disabled" modifiers to n90

### DIFF
--- a/src/Text/Tokens/tokens.ts
+++ b/src/Text/Tokens/tokens.ts
@@ -5,7 +5,7 @@ const tokens = {
     content: {
       color: {
         regular: inube.palette.blue.B400,
-        disabled: inube.palette.neutral.N70,
+        disabled: inube.palette.neutral.N90,
         hover: inube.palette.blue.B300,
       },
     },
@@ -14,7 +14,7 @@ const tokens = {
     content: {
       color: {
         regular: inube.palette.green.G400,
-        disabled: inube.palette.neutral.N70,
+        disabled: inube.palette.neutral.N90,
         hover: inube.palette.green.G300,
       },
     },
@@ -23,7 +23,7 @@ const tokens = {
     content: {
       color: {
         regular: inube.palette.yellow.Y400,
-        disabled: inube.palette.neutral.N70,
+        disabled: inube.palette.neutral.N90,
         hover: inube.palette.yellow.Y300,
       },
     },
@@ -32,7 +32,7 @@ const tokens = {
     content: {
       color: {
         regular: inube.palette.red.R400,
-        disabled: inube.palette.neutral.N70,
+        disabled: inube.palette.neutral.N90,
         hover: inube.palette.red.R300,
       },
     },
@@ -41,7 +41,7 @@ const tokens = {
     content: {
       color: {
         regular: inube.palette.purple.P400,
-        disabled: inube.palette.neutral.N70,
+        disabled: inube.palette.neutral.N90,
         hover: inube.palette.purple.P300,
       },
     },
@@ -50,7 +50,7 @@ const tokens = {
     content: {
       color: {
         regular: inube.palette.neutral.N900,
-        disabled: inube.palette.neutral.N70,
+        disabled: inube.palette.neutral.N90,
         hover: inube.palette.neutral.N500,
       },
     },
@@ -59,7 +59,7 @@ const tokens = {
     content: {
       color: {
         regular: inube.palette.neutral.N300,
-        disabled: inube.palette.neutral.N70,
+        disabled: inube.palette.neutral.N90,
         hover: inube.palette.neutral.N100,
       },
     },
@@ -68,7 +68,7 @@ const tokens = {
     content: {
       color: {
         regular: inube.palette.neutral.N10,
-        disabled: inube.palette.neutral.N70,
+        disabled: inube.palette.neutral.N90,
         hover: inube.palette.neutral.N0,
       },
     },


### PR DESCRIPTION
This PR updates the text tokens by changing the "disabled" modifiers to n90, ensuring that all relevant references to the "disabled" modifiers reflect this new value. The adjustment improves consistency and clarity in the token definitions across the codebase.